### PR TITLE
Do not interfer with system umask.

### DIFF
--- a/lib/daemons/daemonize.rb
+++ b/lib/daemons/daemonize.rb
@@ -116,7 +116,6 @@ module Daemonize
     # NOTE: STDOUT and STDERR will not be redirected to the logfile, because in :ontop mode, we normally want to see the output
     
     Dir.chdir "/"   # Release old working directory
-    File.umask 0000 # Insure sensible umask
 
     # Make sure all file descriptors are closed
     ObjectSpace.each_object(IO) do |io|
@@ -173,7 +172,6 @@ module Daemonize
       $0 = app_name if app_name
       
       Dir.chdir "/"   # Release old working directory
-      File.umask 0000 # Insure sensible umask
   
       # Make sure all file descriptors are closed
       ObjectSpace.each_object(IO) do |io|
@@ -216,7 +214,6 @@ module Daemonize
     $0 = app_name if app_name
     
     Dir.chdir "/"   # Release old working directory
-    File.umask 0000 # Insure sensible umask
 
     # Make sure all file descriptors are closed
     ObjectSpace.each_object(IO) do |io|


### PR DESCRIPTION
Why would you want to tamper your daemon umask (especially for 0000, which is world-writable‽)

I am using your daemons' fork to run delayed_job with delayed_paperclip (uploaded assets management). Why would I want my assets to be world-writtable ?

I know this is not from your patches, but original daemons' one. However, since your fork is the one recommended to run delayed_jobs and being able to restart/stop daemons, I think it would be a good idea to put it into your code base. daemons' upstream (incompatible with delayed_job) had already patched their code with an equivalent modification.
